### PR TITLE
Fix automatic cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Declaration type icons in autocomplete UI
 
 ### Fixed
-- Methods shown in autocomplete
+- Methods are shown in autocomplete
+- Re-indent does not handle comments nor non-data service items well
 
 ## [0.0.8]
 ### Added

--- a/src/main/gen/io/github/facilityapi/intellij/parser/FsdParser.java
+++ b/src/main/gen/io/github/facilityapi/intellij/parser/FsdParser.java
@@ -153,7 +153,7 @@ public class FsdParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // data identifier_declaration '{' decorated_field* '}'
+  // data identifier_declaration '{' (comment+ | decorated_field)* '}'
   public static boolean data_spec(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "data_spec")) return false;
     if (!nextTokenIs(b, DATA)) return false;
@@ -169,61 +169,137 @@ public class FsdParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // decorated_field*
+  // (comment+ | decorated_field)*
   private static boolean data_spec_3(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "data_spec_3")) return false;
     while (true) {
       int c = current_position_(b);
-      if (!decorated_field(b, l + 1)) break;
+      if (!data_spec_3_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "data_spec_3", c)) break;
     }
     return true;
   }
 
+  // comment+ | decorated_field
+  private static boolean data_spec_3_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "data_spec_3_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = data_spec_3_0_0(b, l + 1);
+    if (!r) r = decorated_field(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // comment+
+  private static boolean data_spec_3_0_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "data_spec_3_0_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, COMMENT);
+    while (r) {
+      int c = current_position_(b);
+      if (!consumeToken(b, COMMENT)) break;
+      if (!empty_element_parsed_guard_(b, "data_spec_3_0_0", c)) break;
+    }
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
   /* ********************************************************** */
-  // attribute_list* enum_value
+  // comment+ | attribute_list* enum_value
   public static boolean decorated_enum_value(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "decorated_enum_value")) return false;
-    if (!nextTokenIs(b, "<decorated enum value>", IDENTIFIER, LEFT_BRACKET)) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, DECORATED_ENUM_VALUE, "<decorated enum value>");
     r = decorated_enum_value_0(b, l + 1);
-    r = r && enum_value(b, l + 1);
+    if (!r) r = decorated_enum_value_1(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
 
-  // attribute_list*
+  // comment+
   private static boolean decorated_enum_value_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "decorated_enum_value_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, COMMENT);
+    while (r) {
+      int c = current_position_(b);
+      if (!consumeToken(b, COMMENT)) break;
+      if (!empty_element_parsed_guard_(b, "decorated_enum_value_0", c)) break;
+    }
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // attribute_list* enum_value
+  private static boolean decorated_enum_value_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "decorated_enum_value_1")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = decorated_enum_value_1_0(b, l + 1);
+    r = r && enum_value(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // attribute_list*
+  private static boolean decorated_enum_value_1_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "decorated_enum_value_1_0")) return false;
     while (true) {
       int c = current_position_(b);
       if (!attribute_list(b, l + 1)) break;
-      if (!empty_element_parsed_guard_(b, "decorated_enum_value_0", c)) break;
+      if (!empty_element_parsed_guard_(b, "decorated_enum_value_1_0", c)) break;
     }
     return true;
   }
 
   /* ********************************************************** */
-  // attribute_list* error_spec
+  // comment+ | attribute_list* error_spec
   public static boolean decorated_error_spec(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "decorated_error_spec")) return false;
-    if (!nextTokenIs(b, "<decorated error spec>", IDENTIFIER, LEFT_BRACKET)) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, DECORATED_ERROR_SPEC, "<decorated error spec>");
     r = decorated_error_spec_0(b, l + 1);
-    r = r && error_spec(b, l + 1);
+    if (!r) r = decorated_error_spec_1(b, l + 1);
     exit_section_(b, l, m, r, false, null);
     return r;
   }
 
-  // attribute_list*
+  // comment+
   private static boolean decorated_error_spec_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "decorated_error_spec_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, COMMENT);
+    while (r) {
+      int c = current_position_(b);
+      if (!consumeToken(b, COMMENT)) break;
+      if (!empty_element_parsed_guard_(b, "decorated_error_spec_0", c)) break;
+    }
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // attribute_list* error_spec
+  private static boolean decorated_error_spec_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "decorated_error_spec_1")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = decorated_error_spec_1_0(b, l + 1);
+    r = r && error_spec(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // attribute_list*
+  private static boolean decorated_error_spec_1_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "decorated_error_spec_1_0")) return false;
     while (true) {
       int c = current_position_(b);
       if (!attribute_list(b, l + 1)) break;
-      if (!empty_element_parsed_guard_(b, "decorated_error_spec_0", c)) break;
+      if (!empty_element_parsed_guard_(b, "decorated_error_spec_1_0", c)) break;
     }
     return true;
   }
@@ -580,7 +656,7 @@ public class FsdParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // method identifier_declaration '{' decorated_field* '}' (':' '{' decorated_field* '}')
+  // method identifier_declaration '{' (comment+ | decorated_field)* '}' (':' '{' (comment+ | decorated_field)* '}')
   public static boolean method_spec(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "method_spec")) return false;
     if (!nextTokenIs(b, METHOD)) return false;
@@ -597,18 +673,44 @@ public class FsdParser implements PsiParser, LightPsiParser {
     return r || p;
   }
 
-  // decorated_field*
+  // (comment+ | decorated_field)*
   private static boolean method_spec_3(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "method_spec_3")) return false;
     while (true) {
       int c = current_position_(b);
-      if (!decorated_field(b, l + 1)) break;
+      if (!method_spec_3_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "method_spec_3", c)) break;
     }
     return true;
   }
 
-  // ':' '{' decorated_field* '}'
+  // comment+ | decorated_field
+  private static boolean method_spec_3_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "method_spec_3_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = method_spec_3_0_0(b, l + 1);
+    if (!r) r = decorated_field(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // comment+
+  private static boolean method_spec_3_0_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "method_spec_3_0_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, COMMENT);
+    while (r) {
+      int c = current_position_(b);
+      if (!consumeToken(b, COMMENT)) break;
+      if (!empty_element_parsed_guard_(b, "method_spec_3_0_0", c)) break;
+    }
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // ':' '{' (comment+ | decorated_field)* '}'
   private static boolean method_spec_5(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "method_spec_5")) return false;
     boolean r;
@@ -620,15 +722,41 @@ public class FsdParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // decorated_field*
+  // (comment+ | decorated_field)*
   private static boolean method_spec_5_2(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "method_spec_5_2")) return false;
     while (true) {
       int c = current_position_(b);
-      if (!decorated_field(b, l + 1)) break;
+      if (!method_spec_5_2_0(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "method_spec_5_2", c)) break;
     }
     return true;
+  }
+
+  // comment+ | decorated_field
+  private static boolean method_spec_5_2_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "method_spec_5_2_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = method_spec_5_2_0_0(b, l + 1);
+    if (!r) r = decorated_field(b, l + 1);
+    exit_section_(b, m, null, r);
+    return r;
+  }
+
+  // comment+
+  private static boolean method_spec_5_2_0_0(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "method_spec_5_2_0_0")) return false;
+    boolean r;
+    Marker m = enter_section_(b);
+    r = consumeToken(b, COMMENT);
+    while (r) {
+      int c = current_position_(b);
+      if (!consumeToken(b, COMMENT)) break;
+      if (!empty_element_parsed_guard_(b, "method_spec_5_2_0_0", c)) break;
+    }
+    exit_section_(b, m, null, r);
+    return r;
   }
 
   /* ********************************************************** */

--- a/src/main/gen/io/github/facilityapi/intellij/psi/FsdDecoratedEnumValue.java
+++ b/src/main/gen/io/github/facilityapi/intellij/psi/FsdDecoratedEnumValue.java
@@ -10,7 +10,7 @@ public interface FsdDecoratedEnumValue extends PsiElement {
   @NotNull
   List<FsdAttributeList> getAttributeListList();
 
-  @NotNull
+  @Nullable
   FsdEnumValue getEnumValue();
 
 }

--- a/src/main/gen/io/github/facilityapi/intellij/psi/FsdDecoratedErrorSpec.java
+++ b/src/main/gen/io/github/facilityapi/intellij/psi/FsdDecoratedErrorSpec.java
@@ -10,7 +10,7 @@ public interface FsdDecoratedErrorSpec extends PsiElement {
   @NotNull
   List<FsdAttributeList> getAttributeListList();
 
-  @NotNull
+  @Nullable
   FsdErrorSpec getErrorSpec();
 
 }

--- a/src/main/gen/io/github/facilityapi/intellij/psi/impl/FsdDecoratedEnumValueImpl.java
+++ b/src/main/gen/io/github/facilityapi/intellij/psi/impl/FsdDecoratedEnumValueImpl.java
@@ -34,9 +34,9 @@ public class FsdDecoratedEnumValueImpl extends ASTWrapperPsiElement implements F
   }
 
   @Override
-  @NotNull
+  @Nullable
   public FsdEnumValue getEnumValue() {
-    return findNotNullChildByClass(FsdEnumValue.class);
+    return findChildByClass(FsdEnumValue.class);
   }
 
 }

--- a/src/main/gen/io/github/facilityapi/intellij/psi/impl/FsdDecoratedErrorSpecImpl.java
+++ b/src/main/gen/io/github/facilityapi/intellij/psi/impl/FsdDecoratedErrorSpecImpl.java
@@ -34,9 +34,9 @@ public class FsdDecoratedErrorSpecImpl extends ASTWrapperPsiElement implements F
   }
 
   @Override
-  @NotNull
+  @Nullable
   public FsdErrorSpec getErrorSpec() {
-    return findNotNullChildByClass(FsdErrorSpec.class);
+    return findChildByClass(FsdErrorSpec.class);
   }
 
 }

--- a/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdBlock.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdBlock.kt
@@ -83,7 +83,9 @@ class FsdBlock(
             prevType == FsdTypes.COMMENT ||
             prevType == FsdTypes.COMMA ||
             prevType == FsdTypes.DECORATED_SERVICE_ITEM ||
-            prevType == FsdTypes.DECORATED_FIELD
+            prevType == FsdTypes.DECORATED_FIELD ||
+            prevType == FsdTypes.DECORATED_ENUM_VALUE ||
+            prevType == FsdTypes.DECORATED_ERROR_SPEC
         ) {
             return ChildAttributes(Indent.getNormalIndent(), null)
         }
@@ -94,8 +96,8 @@ class FsdBlock(
     private fun needsParentAlignment(child: ASTNode): Boolean {
         return DEFINITION_SPECS.contains(node.elementType) &&
             child.elementType != FsdTypes.DECORATED_FIELD &&
-            child.elementType != FsdTypes.ENUM_VALUE &&
-            child.elementType != FsdTypes.ERROR_SPEC
+            child.elementType != FsdTypes.DECORATED_ENUM_VALUE &&
+            child.elementType != FsdTypes.DECORATED_ERROR_SPEC
     }
 
     companion object {
@@ -107,6 +109,8 @@ class FsdBlock(
             FsdTypes.ENUM_SPEC,
             FsdTypes.ERROR_SET_SPEC,
             FsdTypes.DECORATED_FIELD,
+            FsdTypes.DECORATED_ENUM_VALUE,
+            FsdTypes.DECORATED_ERROR_SPEC,
         )
     }
 }

--- a/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdBlock.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdBlock.kt
@@ -95,6 +95,7 @@ class FsdBlock(
 
     private fun needsParentAlignment(child: ASTNode): Boolean {
         return DEFINITION_SPECS.contains(node.elementType) &&
+            child.elementType != FsdTypes.COMMENT &&
             child.elementType != FsdTypes.DECORATED_FIELD &&
             child.elementType != FsdTypes.DECORATED_ENUM_VALUE &&
             child.elementType != FsdTypes.DECORATED_ERROR_SPEC

--- a/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdBlock.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdBlock.kt
@@ -104,6 +104,8 @@ class FsdBlock(
     companion object {
         private val DEFINITION_SPECS: Set<IElementType> = hashSetOf(
             FsdTypes.SERVICE_SPEC,
+            FsdTypes.LEFT_BRACE,
+            FsdTypes.RIGHT_BRACE,
             FsdTypes.DECORATED_SERVICE_ITEM,
             FsdTypes.DATA_SPEC,
             FsdTypes.METHOD_SPEC,

--- a/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdIndentProcessor.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdIndentProcessor.kt
@@ -2,29 +2,23 @@ package io.github.facilityapi.intellij.formatting
 
 import com.intellij.formatting.Indent
 import com.intellij.lang.ASTNode
-import com.intellij.psi.impl.source.tree.FileElement
+import io.github.facilityapi.intellij.psi.FsdDataSpec
+import io.github.facilityapi.intellij.psi.FsdEnumValueList
+import io.github.facilityapi.intellij.psi.FsdErrorList
+import io.github.facilityapi.intellij.psi.FsdMethodSpec
+import io.github.facilityapi.intellij.psi.FsdServiceItems
 import io.github.facilityapi.intellij.psi.FsdTypes
 
 class FsdIndentProcessor {
     fun getIndent(node: ASTNode): Indent {
-        if (node.treeParent is FileElement && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.ATTRIBUTE_LIST)) {
-            return Indent.getNoneIndent()
-        }
+        if (node.psi.parent is FsdServiceItems) return Indent.getNormalIndent()
 
-        if (node.elementType in BLOCKS) {
-            return Indent.getNormalIndent()
-        }
+        // todo: figure out comments
+        if (node.psi.parent is FsdMethodSpec && node.elementType == FsdTypes.DECORATED_FIELD) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdDataSpec && node.elementType == FsdTypes.DECORATED_FIELD) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdEnumValueList && node.elementType == FsdTypes.DECORATED_ENUM_VALUE) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdErrorList && node.elementType == FsdTypes.DECORATED_ERROR_SPEC) return Indent.getNormalIndent()
 
         return Indent.getNoneIndent()
-    }
-
-    companion object {
-        val BLOCKS = setOf(
-            FsdTypes.COMMENT,
-            FsdTypes.DECORATED_SERVICE_ITEM,
-            FsdTypes.ENUM_VALUE,
-            FsdTypes.ERROR_SPEC,
-            FsdTypes.DECORATED_FIELD,
-        )
     }
 }

--- a/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdIndentProcessor.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdIndentProcessor.kt
@@ -11,13 +11,14 @@ import io.github.facilityapi.intellij.psi.FsdTypes
 
 class FsdIndentProcessor {
     fun getIndent(node: ASTNode): Indent {
-        if (node.psi.parent is FsdServiceItems) return Indent.getNormalIndent()
+        val parent = node.psi.parent
+        val elementType = node.elementType
 
-        // todo: figure out comments
-        if (node.psi.parent is FsdMethodSpec && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_FIELD)) return Indent.getNormalIndent()
-        if (node.psi.parent is FsdDataSpec && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_FIELD)) return Indent.getNormalIndent()
-        if (node.psi.parent is FsdEnumValueList && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_ENUM_VALUE)) return Indent.getNormalIndent()
-        if (node.psi.parent is FsdErrorList && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_ERROR_SPEC)) return Indent.getNormalIndent()
+        if (parent is FsdServiceItems && elementType !in setOf(FsdTypes.LEFT_BRACE, FsdTypes.RIGHT_BRACE)) return Indent.getNormalIndent()
+        if (parent is FsdMethodSpec && (elementType == FsdTypes.COMMENT || elementType == FsdTypes.DECORATED_FIELD)) return Indent.getNormalIndent()
+        if (parent is FsdDataSpec && (elementType == FsdTypes.COMMENT || elementType == FsdTypes.DECORATED_FIELD)) return Indent.getNormalIndent()
+        if (parent is FsdEnumValueList && (elementType == FsdTypes.COMMENT || elementType == FsdTypes.DECORATED_ENUM_VALUE)) return Indent.getNormalIndent()
+        if (parent is FsdErrorList && (elementType == FsdTypes.COMMENT || elementType == FsdTypes.DECORATED_ERROR_SPEC)) return Indent.getNormalIndent()
 
         return Indent.getNoneIndent()
     }

--- a/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdIndentProcessor.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/formatting/FsdIndentProcessor.kt
@@ -14,10 +14,10 @@ class FsdIndentProcessor {
         if (node.psi.parent is FsdServiceItems) return Indent.getNormalIndent()
 
         // todo: figure out comments
-        if (node.psi.parent is FsdMethodSpec && node.elementType == FsdTypes.DECORATED_FIELD) return Indent.getNormalIndent()
-        if (node.psi.parent is FsdDataSpec && node.elementType == FsdTypes.DECORATED_FIELD) return Indent.getNormalIndent()
-        if (node.psi.parent is FsdEnumValueList && node.elementType == FsdTypes.DECORATED_ENUM_VALUE) return Indent.getNormalIndent()
-        if (node.psi.parent is FsdErrorList && node.elementType == FsdTypes.DECORATED_ERROR_SPEC) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdMethodSpec && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_FIELD)) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdDataSpec && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_FIELD)) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdEnumValueList && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_ENUM_VALUE)) return Indent.getNormalIndent()
+        if (node.psi.parent is FsdErrorList && (node.elementType == FsdTypes.COMMENT || node.elementType == FsdTypes.DECORATED_ERROR_SPEC)) return Indent.getNormalIndent()
 
         return Indent.getNoneIndent()
     }

--- a/src/main/kotlin/io/github/facilityapi/intellij/fsd.bnf
+++ b/src/main/kotlin/io/github/facilityapi/intellij/fsd.bnf
@@ -46,18 +46,18 @@ decorated_service_item ::= attribute_list* service_item
 private service_item ::=  (enum_spec | data_spec | method_spec | error_set_spec) { recoverWhile=service_item_recover }
 private service_item_recover ::= !('[' | '}' | enum | data | errors | method)
 
-method_spec ::= method identifier_declaration '{' decorated_field* '}' (':' '{' decorated_field* '}') { pin=1 }
+method_spec ::= method identifier_declaration '{' (comment+ | decorated_field)* '}' (':' '{' (comment+ | decorated_field)* '}') { pin=1 }
 
-data_spec ::= data identifier_declaration '{' decorated_field* '}' { pin=1 }
+data_spec ::= data identifier_declaration '{' (comment+ | decorated_field)* '}' { pin=1 }
 
 enum_spec ::= enum identifier_declaration enum_value_list { pin=1 }
 enum_value_list ::= '{' [ decorated_enum_value (',' (decorated_enum_value | &'}'))* ] '}' { pin(".*")=1 }
-decorated_enum_value ::= attribute_list* enum_value
+decorated_enum_value ::= (comment+ | attribute_list* enum_value)
 enum_value ::= identifier
 
 error_set_spec ::=  errors identifier_declaration error_list { pin=1 }
 error_list ::= '{' [ decorated_error_spec (',' (decorated_error_spec | &'}'))* ] '}' { pin(".*")=1 }
-decorated_error_spec ::= attribute_list* error_spec
+decorated_error_spec ::= (comment+ | attribute_list* error_spec)
 error_spec ::= identifier
 
 identifier_declaration ::= identifier

--- a/src/test/testData/formatter/indent.fsd
+++ b/src/test/testData/formatter/indent.fsd
@@ -9,6 +9,7 @@
 
 data Widget
 {
+  // a test comment
 [required]
 id: Long;
 }

--- a/src/test/testData/formatter/indent_after.fsd
+++ b/src/test/testData/formatter/indent_after.fsd
@@ -9,6 +9,7 @@ service BadlyIndentedService
 
     data Widget
     {
+        // a test comment
         [required]
         id: Long;
     }


### PR DESCRIPTION
In order to handle after-the-fact automatic re-indent, comments must be represented in the syntax tree in order to be indented in some situations and not indented in others.