### PR TITLE
Add live templates for validation attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 ### Added
 - Inspection for duplicate field names, enum, and error values
 - Intention to add `[validate]` to enum declarations
+- Live Templates for validation attributes
+  - svalid: `[validate(regex: $REGEX$, length: $RANGE$)]`
+  - nvalid: `[validate(value: $RANGE$)]`
+  - cvalid: `[validate(count: $RANGE$)]`
 
 ### Fixed
 - Code folding for method, enum, and error bodies

--- a/src/main/kotlin/io/github/facilityapi/intellij/FsdLiveTemplateContext.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/FsdLiveTemplateContext.kt
@@ -1,0 +1,10 @@
+package io.github.facilityapi.intellij
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.TemplateContextType
+
+class FsdLiveTemplateContext : TemplateContextType(FsdLanguage.id, FsdLanguage.displayName) {
+    override fun isInContext(templateActionContext: TemplateActionContext): Boolean {
+        return templateActionContext.file is FsdFile
+    }
+}

--- a/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateNameInspection.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateNameInspection.kt
@@ -1,4 +1,4 @@
-package io.github.facilityapi.intellij
+package io.github.facilityapi.intellij.inspection
 
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.LocalInspectionToolSession
@@ -8,6 +8,7 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import io.github.facilityapi.intellij.FsdBundle
 import io.github.facilityapi.intellij.psi.FsdDataSpec
 import io.github.facilityapi.intellij.psi.FsdDecoratedField
 import io.github.facilityapi.intellij.psi.FsdEnumSpec

--- a/src/main/kotlin/io/github/facilityapi/intellij/intention/EnumValidateIntention.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/intention/EnumValidateIntention.kt
@@ -1,4 +1,4 @@
-package io.github.facilityapi.intellij
+package io.github.facilityapi.intellij.intention
 
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction
@@ -8,6 +8,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.util.PsiTreeUtil
+import io.github.facilityapi.intellij.FsdBundle
 import io.github.facilityapi.intellij.psi.FsdAttributeList
 import io.github.facilityapi.intellij.psi.FsdDecoratedServiceItem
 import io.github.facilityapi.intellij.psi.FsdEnumSpec

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,11 +87,11 @@
             groupKey="inspections.bugs.duplicatename"
             enabledByDefault="true"
             level="ERROR"
-            implementationClass="io.github.facilityapi.intellij.DuplicateNameInspection" />
+            implementationClass="io.github.facilityapi.intellij.inspection.DuplicateNameInspection" />
 
         <!-- Add validation attribute to field or type -->
         <intentionAction>
-            <className>io.github.facilityapi.intellij.EnumValidateIntention</className>
+            <className>io.github.facilityapi.intellij.intention.EnumValidateIntention</className>
 
             <bundleName>messages.FsdBundle</bundleName>
             <categoryKey>intentions.validate.enum.category</categoryKey>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,6 +79,10 @@
             language="FSD"
             implementationClass="io.github.facilityapi.intellij.FsdBraceMatcher" />
 
+        <defaultLiveTemplates file="/liveTemplates/Facility Service Definition.xml"/>
+        <liveTemplateContext
+            implementation="io.github.facilityapi.intellij.FsdLiveTemplateContext"/>
+
         <!-- Check for duplicate names in service item definitions -->
         <localInspection
             language="FSD"
@@ -92,8 +96,9 @@
         <!-- Add validation attribute to field or type -->
         <intentionAction>
             <className>io.github.facilityapi.intellij.intention.EnumValidateIntention</className>
-
             <bundleName>messages.FsdBundle</bundleName>
+
+            <!--suppress PluginXmlCapitalization -->
             <categoryKey>intentions.validate.enum.category</categoryKey>
         </intentionAction>
 

--- a/src/main/resources/liveTemplates/Facility Service Definition.xml
+++ b/src/main/resources/liveTemplates/Facility Service Definition.xml
@@ -1,0 +1,21 @@
+<templateSet group="Facility Service Definition">
+  <template name="svalid" value="[validate(regex: &quot;$REGEX$&quot;, length: $RANGE$)]" description="String Validate" toReformat="true" toShortenFQNames="true">
+    <variable name="REGEX" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="RANGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="FSD" value="true"/>
+    </context>
+  </template>
+  <template name="cvalid" value="[validate(count: $RANGE$)]" description="Collection Validate" toReformat="true" toShortenFQNames="true">
+    <variable name="RANGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="FSD" value="true"/>
+    </context>
+  </template>
+  <template name="nvalid" value="[validate(value: $RANGE$)]" description="Number Validate" toReformat="true" toShortenFQNames="true">
+    <variable name="RANGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="FSD" value="true"/>
+    </context>
+  </template>
+</templateSet>

--- a/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateNameInspectionTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateNameInspectionTest.kt
@@ -1,6 +1,7 @@
-package io.github.facilityapi.intellij
+package io.github.facilityapi.intellij.inspection
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.facilityapi.intellij.FsdFileType
 
 class DuplicateNameInspectionTest : BasePlatformTestCase() {
 

--- a/src/test/kotlin/io/github/facilityapi/intellij/intention/EnumValidateIntentionTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/intention/EnumValidateIntentionTest.kt
@@ -1,6 +1,7 @@
-package io.github.facilityapi.intellij
+package io.github.facilityapi.intellij.intention
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.github.facilityapi.intellij.intention.EnumValidateIntention
 
 class EnumValidateIntentionTest : BasePlatformTestCase() {
     override fun getTestDataPath() = "src/test/testData"

--- a/src/test/kotlin/io/github/facilityapi/intellij/intention/EnumValidateIntentionTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/intention/EnumValidateIntentionTest.kt
@@ -1,7 +1,6 @@
 package io.github.facilityapi.intellij.intention
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import io.github.facilityapi.intellij.intention.EnumValidateIntention
 
 class EnumValidateIntentionTest : BasePlatformTestCase() {
     override fun getTestDataPath() = "src/test/testData"


### PR DESCRIPTION
- svalid: `[validate(regex: $REGEX$, length: $RANGE$)]`
- nvalid: `[validate(value: $RANGE$)]`
- cvalid: `[validate(count: $RANGE$)]`