### PR TITLE
Detect duplicate service members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [Unreleased]
 ### Added
-- Inspection for duplicate field names, enum, and error values
+- Inspection for duplicate service member names, field names, enum, and error values
 - Intention to add `[validate]` to enum declarations
 - Live Templates for validation attributes
   - svalid: `[validate(regex: $REGEX$, length: $RANGE$)]`

--- a/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspection.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspection.kt
@@ -13,27 +13,47 @@ import io.github.facilityapi.intellij.psi.FsdDataSpec
 import io.github.facilityapi.intellij.psi.FsdDecoratedField
 import io.github.facilityapi.intellij.psi.FsdEnumSpec
 import io.github.facilityapi.intellij.psi.FsdErrorList
+import io.github.facilityapi.intellij.psi.FsdErrorSetSpec
 import io.github.facilityapi.intellij.psi.FsdMethodSpec
+import io.github.facilityapi.intellij.psi.FsdServiceItems
 
-class DuplicateNameInspection : LocalInspectionTool() {
+class DuplicateMemberInspection : LocalInspectionTool() {
     override fun buildVisitor(
         holder: ProblemsHolder,
         isOnTheFly: Boolean,
         session: LocalInspectionToolSession
     ): PsiElementVisitor = object : PsiElementVisitor() {
-        private val fix = Fix()
+        private val serviceMemberFix = ServiceFix()
+        private val fieldFix = FieldFix()
 
         override fun visitElement(element: PsiElement) {
+            if (element is FsdServiceItems) {
+                val seenItems = hashSetOf<String>()
+                for (item in element.decoratedServiceItemList) {
+                    val serviceItemIdentifier = item.dataSpec?.identifierDeclaration ?:
+                    item.methodSpec?.identifierDeclaration ?:
+                    item.errorSetSpec?.identifierDeclaration ?:
+                    item.enumSpec?.identifierDeclaration
+
+                    val name = serviceItemIdentifier?.identifier?.text
+
+                    if (name != null && !seenItems.add(name)) {
+                        val message = FsdBundle.getMessage("inspections.bugs.duplicate.member.service", name)
+                        holder.registerProblem(serviceItemIdentifier, message, serviceMemberFix)
+                    }
+                }
+            }
+
             if (element is FsdMethodSpec) {
                 val requestFields = element.requestFields?.decoratedFieldList ?: emptyList()
-                checkForFieldDuplicates(requestFields, "inspections.bugs.duplicatename.requestfield")
+                checkForFieldDuplicates(requestFields, "inspections.bugs.duplicate.member.requestfield")
 
                 val responseFields = element.responseFields?.decoratedFieldList ?: emptyList()
-                checkForFieldDuplicates(responseFields, "inspections.bugs.duplicatename.responsefield")
+                checkForFieldDuplicates(responseFields, "inspections.bugs.duplicate.member.responsefield")
             }
 
             if (element is FsdDataSpec) {
-                checkForFieldDuplicates(element.decoratedFieldList, "inspections.bugs.duplicatename.field")
+                checkForFieldDuplicates(element.decoratedFieldList, "inspections.bugs.duplicate.member.field")
             }
 
             if (element is FsdEnumSpec) {
@@ -41,8 +61,8 @@ class DuplicateNameInspection : LocalInspectionTool() {
                 for (case in element.enumValueList?.decoratedEnumValueList ?: emptyList()) {
                     val caseName = case.enumValue!!.identifier.text
                     if (!seenCases.add(caseName)) {
-                        val message = FsdBundle.getMessage("inspections.bugs.duplicatename.enumerated", caseName)
-                        holder.registerProblem(case, message, fix)
+                        val message = FsdBundle.getMessage("inspections.bugs.duplicate.member.enumerated", caseName)
+                        holder.registerProblem(case, message, fieldFix)
                     }
                 }
             }
@@ -52,8 +72,8 @@ class DuplicateNameInspection : LocalInspectionTool() {
                 for (decoratedError in element.decoratedErrorSpecList) {
                     val errorName = decoratedError.errorSpec!!.identifier.text
                     if (!seenFields.add(errorName)) {
-                        val message = FsdBundle.getMessage("inspections.bugs.duplicatename.error", errorName)
-                        holder.registerProblem(decoratedError, message, fix)
+                        val message = FsdBundle.getMessage("inspections.bugs.duplicate.member.error", errorName)
+                        holder.registerProblem(decoratedError, message, fieldFix)
                     }
                 }
             }
@@ -66,13 +86,13 @@ class DuplicateNameInspection : LocalInspectionTool() {
                 val fieldName = decoratedField.field.identifier.text
                 if (!seenFields.add(fieldName)) {
                     val message = FsdBundle.getMessage(bundleKey, fieldName)
-                    holder.registerProblem(decoratedField, message, fix)
+                    holder.registerProblem(decoratedField, message, fieldFix)
                 }
             }
         }
     }
 
-    class Fix : LocalQuickFix {
+    class FieldFix : LocalQuickFix {
         override fun getFamilyName() = NAME
 
         override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
@@ -80,7 +100,24 @@ class DuplicateNameInspection : LocalInspectionTool() {
         }
 
         companion object {
-            val NAME = FsdBundle.getMessage("inspections.bugs.duplicatenames.quickfix")
+            val NAME = FsdBundle.getMessage("inspections.bugs.duplicate.member.quickfix")
+        }
+    }
+
+    class ServiceFix : LocalQuickFix {
+        private val PsiElement.isServiceItem: Boolean
+            get() = this is FsdMethodSpec || this is FsdDataSpec || this is FsdEnumSpec || this is FsdErrorSetSpec
+
+        override fun getFamilyName() = NAME
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            var element: PsiElement? = descriptor.psiElement
+            while (element != null && !element.isServiceItem) { element = element.parent }
+            element?.delete()
+        }
+
+        companion object {
+            val NAME = FsdBundle.getMessage("inspections.bugs.duplicate.member.quickfix")
         }
     }
 }

--- a/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspection.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspection.kt
@@ -30,10 +30,10 @@ class DuplicateMemberInspection : LocalInspectionTool() {
             if (element is FsdServiceItems) {
                 val nameGroups = element.decoratedServiceItemList
                     .mapNotNull {
-                        it.dataSpec?.identifierDeclaration ?:
-                        it.methodSpec?.identifierDeclaration ?:
-                        it.errorSetSpec?.identifierDeclaration ?:
-                        it.enumSpec?.identifierDeclaration
+                        it.dataSpec?.identifierDeclaration
+                            ?: it.methodSpec?.identifierDeclaration
+                            ?: it.errorSetSpec?.identifierDeclaration
+                            ?: it.enumSpec?.identifierDeclaration
                     }.groupBy { it.identifier.text }
 
                 for ((memberName, memberIds) in nameGroups.filter { it.value.size > 1 }) {

--- a/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspection.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspection.kt
@@ -80,13 +80,11 @@ class DuplicateMemberInspection : LocalInspectionTool() {
         }
 
         private fun checkForFieldDuplicates(fields: List<FsdDecoratedField>, bundleKey: String) {
-            val seenFields = hashSetOf<String>()
-
-            for (decoratedField in fields) {
-                val fieldName = decoratedField.field.identifier.text
-                if (!seenFields.add(fieldName)) {
-                    val message = FsdBundle.getMessage(bundleKey, fieldName)
-                    holder.registerProblem(decoratedField, message, fieldFix)
+            val nameGroups = fields.groupBy { it.field.identifier.text }
+            for ((fieldName, elements) in nameGroups.filter { it.value.size > 1 }) {
+                val message = FsdBundle.getMessage(bundleKey, fieldName)
+                for (element in elements) {
+                    holder.registerProblem(element, message, fieldFix)
                 }
             }
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,12 +86,12 @@
         <!-- Check for duplicate names in service item definitions -->
         <localInspection
             language="FSD"
-            displayName="DuplicateName"
+            displayName="DuplicateMember"
             groupBundle="messages.FsdBundle"
-            groupKey="inspections.bugs.duplicatename"
+            groupKey="inspections.bugs.duplicate.member"
             enabledByDefault="true"
             level="ERROR"
-            implementationClass="io.github.facilityapi.intellij.inspection.DuplicateNameInspection" />
+            implementationClass="io.github.facilityapi.intellij.inspection.DuplicateMemberInspection" />
 
         <!-- Add validation attribute to field or type -->
         <intentionAction>

--- a/src/main/resources/inspectionDescriptions/DuplicateMember.html
+++ b/src/main/resources/inspectionDescriptions/DuplicateMember.html
@@ -1,6 +1,6 @@
 <html>
 <body>
-Identifies duplicate names in request, response, data, enum, or error definitions.
+Identifies duplicate names in service member, request, response, data, enum, or error definitions.
 <p>
     The quick-fix can delete a duplicate definition.
 </p>

--- a/src/main/resources/messages/FsdBundle.properties
+++ b/src/main/resources/messages/FsdBundle.properties
@@ -60,13 +60,14 @@ settings.color.displayname.typeref=Type reference
 settings.color.displayname.attribute=Attribute
 settings.color.displayname.attributeparametervalue=Attribute parameter value
 
-inspections.bugs.duplicatename=Duplicate name
-inspections.bugs.duplicatename.field=Duplicate field: {0}
-inspections.bugs.duplicatename.requestfield=Duplicate request field: {0}
-inspections.bugs.duplicatename.responsefield=Duplicate response field: {0}
-inspections.bugs.duplicatename.enumerated=Duplicate enumerated value: {0}
-inspections.bugs.duplicatename.error=Duplicate error: {0}
-inspections.bugs.duplicatenames.quickfix=Delete duplicate
+inspections.bugs.duplicate.member=Duplicate member
+inspections.bugs.duplicate.member.service=Duplicate service member: {0}
+inspections.bugs.duplicate.member.field=Duplicate field: {0}
+inspections.bugs.duplicate.member.requestfield=Duplicate request field: {0}
+inspections.bugs.duplicate.member.responsefield=Duplicate response field: {0}
+inspections.bugs.duplicate.member.enumerated=Duplicate enumerated value: {0}
+inspections.bugs.duplicate.member.error=Duplicate error: {0}
+inspections.bugs.duplicate.member.quickfix=Delete duplicate
 
 intentions.validate.enum.text=Add [validate] attribute to enum
 intentions.validate.enum.familyname=Enum validation

--- a/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspectionTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspectionTest.kt
@@ -355,7 +355,10 @@ class DuplicateMemberInspectionTest : BasePlatformTestCase() {
         myFixture.configureByText(FsdFileType, code)
         myFixture.enableInspections(DuplicateMemberInspection())
         val highlights = myFixture.doHighlighting()
-        assertEquals(errorDescription, highlights.singleOrNull()?.description)
+
+        for (highlight in highlights) {
+            assertEquals(errorDescription, highlight.description)
+        }
     }
 
     private fun checkFix(before: String, after: String) {

--- a/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspectionTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspectionTest.kt
@@ -1,5 +1,6 @@
 package io.github.facilityapi.intellij.inspection
 
+import com.intellij.testFramework.UsefulTestCase
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import io.github.facilityapi.intellij.FsdFileType
 
@@ -355,6 +356,8 @@ class DuplicateMemberInspectionTest : BasePlatformTestCase() {
         myFixture.configureByText(FsdFileType, code)
         myFixture.enableInspections(DuplicateMemberInspection())
         val highlights = myFixture.doHighlighting()
+
+        UsefulTestCase.assertSize(2, highlights)
 
         for (highlight in highlights) {
             assertEquals(errorDescription, highlight.description)

--- a/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspectionTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/inspection/DuplicateMemberInspectionTest.kt
@@ -3,9 +3,33 @@ package io.github.facilityapi.intellij.inspection
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import io.github.facilityapi.intellij.FsdFileType
 
-class DuplicateNameInspectionTest : BasePlatformTestCase() {
+class DuplicateMemberInspectionTest : BasePlatformTestCase() {
 
     override fun getTestDataPath() = "src/test/testData"
+
+    fun testDuplicateServiceMemberInspection() {
+        val code = """
+        service MessageService {
+            enum Message
+            {
+                audio,
+                video,
+                text
+            }
+
+            data Message
+            {
+                /// A unique identifier for the conversation
+                [required]
+                id: int64;
+
+                text: string;
+            }
+        }
+        """
+
+        checkInspection(code, "Duplicate service member: Message")
+    }
 
     fun testDuplicateRequestFieldInspection() {
         val code = """
@@ -108,6 +132,42 @@ class DuplicateNameInspectionTest : BasePlatformTestCase() {
         """
 
         checkInspection(code, "Duplicate error: accountBanned")
+    }
+
+    fun testDuplicateServiceMemberFix() {
+        val before = """
+        service MessageService {
+            enum Message
+            {
+                audio,
+                video,
+                text
+            }
+
+            data Mes<caret>sage
+            {
+                /// A unique identifier for the conversation
+                [required]
+                id: int64;
+
+                text: string;
+            }
+        }
+        """.trimIndent()
+
+        val after = """
+        service MessageService {
+            enum Message
+            {
+                audio,
+                video,
+                text
+            }
+
+            }
+        """.trimIndent()
+
+        checkFix(before, after)
     }
 
     fun testDuplicateRequestFieldFix() {
@@ -293,17 +353,17 @@ class DuplicateNameInspectionTest : BasePlatformTestCase() {
 
     private fun checkInspection(code: String, errorDescription: String) {
         myFixture.configureByText(FsdFileType, code)
-        myFixture.enableInspections(DuplicateNameInspection())
+        myFixture.enableInspections(DuplicateMemberInspection())
         val highlights = myFixture.doHighlighting()
         assertEquals(errorDescription, highlights.singleOrNull()?.description)
     }
 
     private fun checkFix(before: String, after: String) {
         myFixture.configureByText(FsdFileType, before)
-        myFixture.enableInspections(DuplicateNameInspection())
+        myFixture.enableInspections(DuplicateMemberInspection())
         myFixture.doHighlighting()
 
-        val intention = myFixture.findSingleIntention(DuplicateNameInspection.Fix.NAME)
+        val intention = myFixture.findSingleIntention(DuplicateMemberInspection.FieldFix.NAME)
         myFixture.launchAction(intention)
 
         myFixture.checkResult(after)


### PR DESCRIPTION
Also improve the duplicate detection for other members.

Resolves #35 