### PR TITLE
Use file-based test data

### DIFF
--- a/src/test/kotlin/io/github/facilityapi/intellij/FsdFindUsageProviderTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/FsdFindUsageProviderTest.kt
@@ -5,72 +5,20 @@ import assertk.assertions.hasSize
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 
 class FsdFindUsageProviderTest : BasePlatformTestCase() {
-    fun `test find usages works from type definition`() {
-        myFixture.configureByText(
-            FsdLanguage.associatedFileType,
-            """
-                service FsdFindUsages
-                {
-                    data Car
-                    {
-                        wheel: Wheel[];
-                        spare: Wheel;
-                    }
+    override fun getTestDataPath(): String = "src/test/testData/findUsages"
 
-                    data Whe<caret>el
-                    {
-                        id: int64;
-                    }
-                }
-            """.trimIndent()
-        )
-        val usages = myFixture.findUsages(myFixture.elementAtCaret)
+    fun `test find usages works from type definition`() {
+        val usages = myFixture.testFindUsagesUsingAction("typeDefinition.fsd")
         assertThat(usages, "usages").hasSize(2)
     }
 
     fun `test find usages works from type reference on arrays`() {
-        myFixture.configureByText(
-            FsdLanguage.associatedFileType,
-            """
-                service FsdFindUsages
-                {
-                    data Car
-                    {
-                        wheel: Wh<caret>eel[];
-                        spare: Wheel;
-                    }
-
-                    data Wheel
-                    {
-                        id: int64;
-                    }
-                }
-            """.trimIndent()
-        )
-        val usages = myFixture.findUsages(myFixture.elementAtCaret)
+        val usages = myFixture.testFindUsagesUsingAction("arrays.fsd")
         assertThat(usages, "usages").hasSize(2)
     }
 
     fun `test find usages works from type reference`() {
-        myFixture.configureByText(
-            FsdLanguage.associatedFileType,
-            """
-                service FsdFindUsages
-                {
-                    data Car
-                    {
-                        wheel: Wheel[];
-                        spare: Wh<caret>eel;
-                    }
-
-                    data Wheel
-                    {
-                        id: int64;
-                    }
-                }
-            """.trimIndent()
-        )
-        val usages = myFixture.findUsages(myFixture.elementAtCaret)
+        val usages = myFixture.testFindUsagesUsingAction("typeReference.fsd")
         assertThat(usages, "usages").hasSize(2)
     }
 }

--- a/src/test/kotlin/io/github/facilityapi/intellij/FsdRenameTypeTest.kt
+++ b/src/test/kotlin/io/github/facilityapi/intellij/FsdRenameTypeTest.kt
@@ -1,38 +1,11 @@
 package io.github.facilityapi.intellij
 
-import assertk.all
-import assertk.assertThat
-import assertk.assertions.contains
-import assertk.assertions.doesNotContain
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.junit.Ignore
 
 class FsdRenameTypeTest : BasePlatformTestCase() {
-    @Ignore
+    override fun getTestDataPath(): String = "src/test/testData/rename"
+
     fun `test rename type from reference`() {
-        myFixture.configureByText(
-            FsdLanguage.associatedFileType,
-            """
-                service FsdFindUsages
-                {
-                    data Car
-                    {
-                        wheel: Wheel[];
-                        spare: Wheel;
-                    }
-
-                    data Wh<caret>eel
-                    {
-                        id: int64;
-                    }
-                }
-            """.trimIndent()
-        )
-        myFixture.renameElement(myFixture.elementAtCaret, "Rim")
-
-        assertThat(myFixture.editor.document.text, "document text").all {
-            doesNotContain("Wheel")
-            contains("Rim")
-        }
+        myFixture.testRename("before.fsd", "after.fsd", "Rim")
     }
 }

--- a/src/test/testData/findUsages/arrays.fsd
+++ b/src/test/testData/findUsages/arrays.fsd
@@ -1,0 +1,13 @@
+service FsdFindUsages
+{
+	data Car
+	{
+		wheel: W<caret>heel[];
+		spare: Wheel;
+	}
+
+	data Wheel
+	{
+		id: int64;
+	}
+}

--- a/src/test/testData/findUsages/typeDefinition.fsd
+++ b/src/test/testData/findUsages/typeDefinition.fsd
@@ -1,0 +1,13 @@
+service FsdFindUsages
+{
+	data Car
+	{
+		wheel: Wheel[];
+		spare: Wheel;
+	}
+
+	data Whe<caret>el
+	{
+		id: int64;
+	}
+}

--- a/src/test/testData/findUsages/typeReference.fsd
+++ b/src/test/testData/findUsages/typeReference.fsd
@@ -1,0 +1,13 @@
+service FsdFindUsages
+{
+	data Car
+	{
+		wheel: Wheel[];
+		spare: W<caret>heel;
+	}
+
+	data Wheel
+	{
+		id: int64;
+	}
+}

--- a/src/test/testData/rename/after.fsd
+++ b/src/test/testData/rename/after.fsd
@@ -1,0 +1,13 @@
+service FsdFindUsages
+{
+	data Car
+	{
+		wheel: Rim[];
+		spare: Rim;
+	}
+
+	data Rim
+	{
+		id: int64;
+	}
+}

--- a/src/test/testData/rename/before.fsd
+++ b/src/test/testData/rename/before.fsd
@@ -1,0 +1,13 @@
+service FsdFindUsages
+{
+	data Car
+	{
+		wheel: Wheel[];
+		spare: Wheel;
+	}
+
+	data Wh<caret>eel
+	{
+		id: int64;
+	}
+}


### PR DESCRIPTION
7d7857dcfe506db0ffd550d076a7a39bddb5020c made this possible.
Previously, the FileTypeIndex was broken when the test fixture
was initialized with file-based test data. This broke references,
which made testing many subsystems of the plugin impossible with
file-based test data.