### PR TITLE
Remove plugin validation on unsupported version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginUntilBuild = 222.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2020.3.4, 2021.1.3, 2021.2.1, 2021.3.2, 2022.1, 2022.2
+pluginVerifierIdeVersions = 2021.1.3, 2021.2.1, 2021.3.2, 2022.1, 2022.2
 
 platformType = IC
 platformVersion = 2021.1.1

--- a/src/main/kotlin/io/github/facilityapi/intellij/FsdUtilities.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/FsdUtilities.kt
@@ -1,10 +1,10 @@
 package io.github.facilityapi.intellij
 
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.descendants
 import io.github.facilityapi.intellij.psi.FsdNamedElement
 
 fun findTypeDefinitions(project: Project, name: String): Sequence<FsdNamedElement> {
@@ -21,25 +21,5 @@ fun findTypeDefinitions(project: Project): Sequence<FsdNamedElement> {
     return FileTypeIndex.getFiles(FsdLanguage.associatedFileType, GlobalSearchScope.allScope(project)).asSequence()
         .map { PsiManager.getInstance(project).findFile(it) }
         .filterIsInstance<FsdFile>()
-        .flatMap { it.descendants.filterIsInstance<FsdNamedElement>() }
-}
-
-// These are copied because of a source breaking change in the framework
-// JetBrains Platform Slack: https://app.slack.com/client/T5P9YATH9/threads
-// Eventually, they should be replaced with PsiElement.descendents() in psiTreeUtil.kt
-val PsiElement.descendants: Sequence<PsiElement>
-    get() = sequence {
-        val root = this@descendants
-        visitChildrenAndYield(root)
-    }
-
-private suspend fun SequenceScope<PsiElement>.visitChildrenAndYield(element: PsiElement) {
-    var child = element.firstChild
-
-    while (child != null) {
-        visitChildrenAndYield(child)
-        child = child.nextSibling
-    }
-
-    yield(element)
+        .flatMap { it.descendants().filterIsInstance<FsdNamedElement>() }
 }

--- a/src/main/kotlin/io/github/facilityapi/intellij/inspection/UnusedTypeInspection.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/inspection/UnusedTypeInspection.kt
@@ -5,8 +5,8 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.descendants
 import io.github.facilityapi.intellij.FsdBundle
-import io.github.facilityapi.intellij.descendants
 import io.github.facilityapi.intellij.psi.FsdDataSpec
 import io.github.facilityapi.intellij.psi.FsdEnumSpec
 import io.github.facilityapi.intellij.psi.FsdNamedElement
@@ -19,7 +19,7 @@ class UnusedTypeInspection : LocalInspectionTool() {
             override fun visitElement(element: PsiElement) {
                 val namedElement = element as? FsdNamedElement ?: return
 
-                val isUsed = element.containingFile.descendants
+                val isUsed = element.containingFile.descendants()
                     .filterIsInstance<FsdReferenceType>()
                     .filter { it.typename.textMatches(namedElement.nameIdentifier!!.text) } // fast but imprecise
                     .any { it.reference.isReferenceTo(namedElement) } // precise but slower

--- a/src/main/kotlin/io/github/facilityapi/intellij/reference/FsdElementFactory.kt
+++ b/src/main/kotlin/io/github/facilityapi/intellij/reference/FsdElementFactory.kt
@@ -4,9 +4,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
+import com.intellij.psi.util.descendants
 import io.github.facilityapi.intellij.FsdFile
 import io.github.facilityapi.intellij.FsdLanguage
-import io.github.facilityapi.intellij.descendants
 import io.github.facilityapi.intellij.psi.FsdAttributeList
 import io.github.facilityapi.intellij.psi.FsdNamedElement
 import io.github.facilityapi.intellij.psi.FsdReferenceType
@@ -58,7 +58,7 @@ fun createFromText(project: Project, text: String): Sequence<PsiElement> {
     val file = PsiFileFactory.getInstance(project)
         .createFileFromText(fileName, FsdLanguage, text) as FsdFile
 
-    return file.descendants
+    return file.descendants()
 }
 
 fun addAttribute(element: PsiElement, attributeText: String) {


### PR DESCRIPTION
Support for platform 2020.3 was dropped in faabc6b02f24b752acce0ec8b49a9f9ad5ddf995, but plugin validation wasn't updated to match. This also means that a workaround for a breaking change in the platform was no longer necessary.